### PR TITLE
Refactor commands.ts to optimize JSON parsing

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,9 +39,16 @@ export async function convertJsonToSqlite(fileUri: vscode.Uri | undefined) {
             db.serialize(() => {
                 if (Array.isArray(jsonData) && jsonData.length > 0 && typeof jsonData[0] === 'object') {
                     if (!Array.isArray(jsonData[0])) {
-                        handleSingleTableFormat(db, jsonData, fileName, useFilenameAsTableName, customTableName);
-                    } else {
-                        handleMultipleTablesFormat(db, jsonData);
+                        const jsonDataEntry = jsonData[0];
+                        const keys = Object.keys(jsonData[0]);
+                        if (keys && keys.length > 0) {
+                            if (Array.isArray(jsonDataEntry[keys[0]])) {
+                                handleMultipleTablesFormat(db, jsonData);
+                            }
+                            else {
+                                handleSingleTableFormat(db, jsonData, fileName, useFilenameAsTableName, customTableName);
+                            }
+                        }
                     }
                 } else if (typeof jsonData === 'object') {
                     handleNamedTableFormat(db, jsonData);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -62,11 +62,13 @@ export async function convertJsonToSqlite(fileUri: vscode.Uri | undefined) {
 }
 
 function handleSingleTableFormat(db: any, jsonData: any[], fileName: string, useFilenameAsTableName: boolean, customTableName: string) {
+    // [{"field1": "a", "field2": "b"}]
     const tableName = useFilenameAsTableName ? fileName : customTableName || 'data';
     createTableAndInsertData(db, tableName, jsonData);
 }
 
 function handleNamedTableFormat(db: any, jsonData: any) {
+    // { "table1": [{"field1": "a", "field2": "b"}], "table2": [{"field1": "a", "field2": "b"}] }
     const tableNames = Object.keys(jsonData);
     tableNames.forEach(tableName => {
         createTableAndInsertData(db, tableName, jsonData[tableName]);
@@ -74,6 +76,7 @@ function handleNamedTableFormat(db: any, jsonData: any) {
 }
 
 function handleMultipleTablesFormat(db: any, jsonData: any[]) {
+    // [ { "table1": [{"field1": "a", "field2": "b"}] }, { "table2": [{"field1": "c", "field2": "d"}, {"field1": "e", "field2": "f"}] } ]
     jsonData.forEach((tableData: any) => {
         const tableName = Object.keys(tableData)[0];
         createTableAndInsertData(db, tableName, tableData[tableName]);


### PR DESCRIPTION
Refactor `convertJsonToSqlite` function in `src/commands.ts` to handle different JSON formats more efficiently.

* Create `handleSingleTableFormat` function to handle single table JSON format.
* Create `handleNamedTableFormat` function to handle named table JSON format.
* Create `handleMultipleTablesFormat` function to handle multiple tables JSON format.
* Update `convertJsonToSqlite` function to call the appropriate new functions based on JSON format.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/primaryobjects/json-to-sqlite/pull/3?shareId=f87bd314-b915-4b0d-9010-1b2e65424bab).